### PR TITLE
fix: 如果sogou搜索的公众号结果为空时异常的问题

### DIFF
--- a/test/__init__.py
+++ b/test/__init__.py
@@ -10,5 +10,6 @@ from wechatsogou.structuring import WechatSogouStructuring
 ws = WechatSogouRequest()
 ws_structuring = WechatSogouStructuring()
 
+empty_search_result_keyword = 'gggggggggggggggggg'
 gaokao_keyword = '高考'
 fake_data_path = '{}/file'.format(os.getcwd() if 'test' in os.getcwd() else '{}/test'.format(os.getcwd()))

--- a/test/test_api.py
+++ b/test/test_api.py
@@ -6,12 +6,12 @@ import os
 import time
 import unittest
 
-from nose.tools import assert_equal, assert_true, assert_in, assert_greater_equal
+from nose.tools import assert_equal, assert_true, assert_in, assert_greater_equal, raises
 
 from wechatsogou.const import WechatSogouConst
 from wechatsogou.api import WechatSogouAPI
 from wechatsogou.identify_image import identify_image_callback_by_hand
-from test import gaokao_keyword
+from test import gaokao_keyword, empty_search_result_keyword
 from test.rk import identify_image_callback_ruokuai_sogou, identify_image_callback_ruokuai_weixin
 
 ws_api = WechatSogouAPI(captcha_break_time=3)
@@ -70,6 +70,12 @@ class TestAPIReal(unittest.TestCase):
 
         assert_in('content_html', article_info)
         assert_in('content_img_list', article_info)
+
+    @raises(Exception)
+    def test_gzh_by_history_profile_none(self):
+        gzh_article = ws_api.get_gzh_article_by_history(empty_search_result_keyword,
+                                                        identify_image_callback_sogou=self.identify_image_callback_sogou,
+                                                        identify_image_callback_weixin=self.identify_image_callback_ruokuai_weixin)
 
 
 if __name__ == '__main__':

--- a/test/test_api.py
+++ b/test/test_api.py
@@ -6,7 +6,7 @@ import os
 import time
 import unittest
 
-from nose.tools import assert_equal, assert_true, assert_in, assert_greater_equal, raises
+from nose.tools import assert_equal, assert_true, assert_in, assert_greater_equal 
 
 from wechatsogou.const import WechatSogouConst
 from wechatsogou.api import WechatSogouAPI
@@ -71,11 +71,11 @@ class TestAPIReal(unittest.TestCase):
         assert_in('content_html', article_info)
         assert_in('content_img_list', article_info)
 
-    @raises(Exception)
     def test_gzh_by_history_profile_none(self):
         gzh_article = ws_api.get_gzh_article_by_history(empty_search_result_keyword,
                                                         identify_image_callback_sogou=self.identify_image_callback_sogou,
                                                         identify_image_callback_weixin=self.identify_image_callback_ruokuai_weixin)
+        assert_equal({}, gzh_article)
 
 
 if __name__ == '__main__':

--- a/wechatsogou/api.py
+++ b/wechatsogou/api.py
@@ -360,7 +360,9 @@ class WechatSogouAPI(object):
         """
         if url is None:
             gzh_list = self.get_gzh_info(keyword, unlock_callback_sogou, identify_image_callback_sogou)
-            if gzh_list is None or 'profile_url' not in gzh_list:
+            if gzh_list is None:
+                return {}
+            if 'profile_url' not in gzh_list:
                 raise Exception()  # todo use ws exception
             url = gzh_list['profile_url']
 

--- a/wechatsogou/api.py
+++ b/wechatsogou/api.py
@@ -360,7 +360,7 @@ class WechatSogouAPI(object):
         """
         if url is None:
             gzh_list = self.get_gzh_info(keyword, unlock_callback_sogou, identify_image_callback_sogou)
-            if 'profile_url' not in gzh_list:
+            if gzh_list is None or 'profile_url' not in gzh_list:
                 raise Exception()  # todo use ws exception
             url = gzh_list['profile_url']
 


### PR DESCRIPTION
```python
Traceback (most recent call last):
  File "main.py", line 17, in <module>
    resp = ws_api.get_gzh_article_by_history(l)
  File "/Users/edison.hsu/.pyenv/versions/3.6.0/lib/python3.6/site-packages/wechatsogou/api.py", line 363, in get_gzh_article_by_history
    if 'profile_url' not in gzh_list:
TypeError: argument of type 'NoneType' is not iterable
```
搜索一些公众号 id 的时候，会出现搜索结果为空的情况。
本来会报出 TypeError，增加代码判断，如果为空就走异常处理流程