### PR TITLE
修复缺陷#231，搜狗反爬增加UA判断

### DIFF
--- a/wechatsogou/api.py
+++ b/wechatsogou/api.py
@@ -121,7 +121,9 @@ class WechatSogouAPI(object):
             if '请输入验证码' in resp.text:
                 resp = session.get(url)
             else:
-                resp = self.__get(url, session, headers=self.__set_cookie(referer=referer))
+                headers = self.__set_cookie(referer=referer)
+                headers['User-Agent'] = 'Mozilla/5.0 (Windows NT 6.1; WOW64)'
+                resp = self.__get(url, session, headers)
 
         return resp
 


### PR DESCRIPTION
修改api.py， 发送请求时增加User-Agent
```
    def __get_by_unlock(self, url, referer=None, unlock_platform=None, unlock_callback=None,
                        identify_image_callback=None):
        assert unlock_platform is None or callable(unlock_platform)

        if identify_image_callback is None:
            identify_image_callback = identify_image_callback_by_hand
        assert unlock_callback is None or callable(unlock_callback)
        assert callable(identify_image_callback)

        session = requests.session()
        resp = self.__get(url, session, headers=self.__set_cookie(referer=referer))
        if 'antispider' in resp.url or '请输入验证码' in resp.text:
            for i in range(self.captcha_break_times):
                try:
                    unlock_platform(url, resp, session, unlock_callback, identify_image_callback)
                    break
                except WechatSogouVcodeOcrException as e:
                    if i == self.captcha_break_times - 1:
                        raise WechatSogouVcodeOcrException(e)

            if '请输入验证码' in resp.text:
                resp = session.get(url)
            else:
                headers = self.__set_cookie(referer=referer)
                headers['User-Agent'] = 'Mozilla/5.0 (Windows NT 6.1; WOW64)'
                resp = self.__get(url, session, headers)
```