### PR TITLE
修改空返回值是空generator的处理，避免出现StopIteration错误

### DIFF
--- a/wechatsogou/api.py
+++ b/wechatsogou/api.py
@@ -224,13 +224,11 @@ class WechatSogouAPI(object):
                 'authentication': ''  # 认证
             }
         """
-        info = self.search_gzh(wecgat_id_or_name, 1, unlock_callback, identify_image_callback)
-        if not info:
-            return None
-        if decode_url:
+        info = self.search_gzh(wecgat_id_or_name, 1, unlock_callback, identify_image_callback, decode_url)
+        try:
             return next(info)
-
-        return info
+        except StopIteration:
+            return None
 
     def search_gzh(self, keyword, page=1, unlock_callback=None, identify_image_callback=None, decode_url=True):
         """搜索 公众号


### PR DESCRIPTION
1、`WechatSogouStructuring.get_gzh_by_search`返回结果是空list时，生成的generator也为空，使用next会提示`StopIteration`错误
2、`get_gzh_info`调用`search_gzh`时，加入参数`decode_url`传入