### PR TITLE
`pip install -e .`报错了 

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,14 +1,16 @@
 import codecs
-from setuptools import setup
+import re
 
-import wechatsogou
+from setuptools import setup
 
 readme = codecs.open('docs/README.rst', encoding='utf-8').read()
 history = codecs.open('docs/HISTORY.rst', encoding='utf-8').read()
+with codecs.open("wechatsogou/__init__.py", encoding="utf8") as f:
+    version = re.search(r'__version__ = "(.*?)"', f.read()).group(1)
 
 setup(
     name='wechatsogou',
-    version=wechatsogou.__version__,
+    version=version,
     description='Api for wechat mp with sogou',
     long_description=u'\n\n'.join([readme, history]),
     author='Chyroc',


### PR DESCRIPTION
`pip install -e .`报错了:
```
Looking in indexes: https://mirrors.aliyun.com/pypi/simple
Obtaining file:///home/jason/workspace/opensource/WechatSogou
    ERROR: Command errored out with exit status 1:
     command: /home/jason/.venv/wechatsogou_env/bin/python3.7 -c 'import sys, setuptools, tokenize; sys.argv[0] = '"'"'/home/jason/workspace/opensource/WechatSogou/setup.py'"'"'; __file__='"'"'/home/jason/workspace/opensource/WechatSogou/setup.py'"'"';f=getattr(tokenize, '"'"'open'"'"', open)(__file__);code=f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' egg_info
         cwd: /home/jason/workspace/opensource/WechatSogou/
    Complete output (5 lines):
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/home/jason/workspace/opensource/WechatSogou/setup.py", line 6, in <module>
        open()
    TypeError: open() missing required argument 'file' (pos 1)
    ----------------------------------------
ERROR: Command errored out with exit status 1: python setup.py egg_info Check the logs for full command output.
```