### PR TITLE
werkzeug.contrib已经在1.0版本被移除了，使用cachelib

### DIFF
--- a/wechatsogou/filecache.py
+++ b/wechatsogou/filecache.py
@@ -1,6 +1,9 @@
 # -*- coding: utf-8 -*-
 
-from werkzeug.contrib.cache import FileSystemCache
+try:
+    from werkzeug.contrib.cache import FileSystemCache
+except ImportError:
+    from cachelib import FileSystemCache
 
 
 class WechatCache(FileSystemCache):


### PR DESCRIPTION
werkzeug.contrib已经在1.0版本被移除了，使用cachelib